### PR TITLE
Add missing QML dependency.

### DIFF
--- a/rpm/flowplayer.spec
+++ b/rpm/flowplayer.spec
@@ -40,6 +40,9 @@ Source0:    %{url}/archive/%{release}/%{version}/%{name}-%{version}.tar.gz
 Source99:   %{name}.rpmlintrc
 Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   qml(org.nemomobile.mpris)
+Requires:   qml(org.nemomobile.policy)
+Requires:   qml(org.nemomobile.thumbnailer)
+Requires:   qml(com.jolla.mediaplayer)
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)


### PR DESCRIPTION
Following @nephros suggestion, I'm adding `Requires: qml(org.nemomobile.mpris)` but also for `org.nemomobile.policy` and for `org.nemomobile.thumbnailer` which are used in various QML files.

I'm hesitating to also add `Requires: qml(com.jolla.mediaplayer)` which is imported by the main `flowplayer.qml` file. What do you think ?