### PR TITLE
[flowplayer.spec] Add `Requires: qml(org.nemomobile.mpris)` …

### DIFF
--- a/rpm/flowplayer.spec
+++ b/rpm/flowplayer.spec
@@ -39,6 +39,7 @@ Source0:    %{url}/archive/%{release}/%{version}/%{name}-%{version}.tar.gz
 # https://en.opensuse.org/openSUSE:Packaging_checks#Building_Packages_in_spite_of_errors
 Source99:   %{name}.rpmlintrc
 Requires:   sailfishsilica-qt5 >= 0.10.9
+Requires:   qml(org.nemomobile.mpris)
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)


### PR DESCRIPTION
… as [suggested by @nephros](https://forum.sailfishos.org/t/reviving-cepiperezs-flowplayer/17532/13?u=olf).
May use alternatively: `Requires: mpris-qt5-qml-plugin`