### PR TITLE
Fix various ways of album cover download

### DIFF
--- a/qml/pages/AlbumListView.qml
+++ b/qml/pages/AlbumListView.qml
@@ -44,7 +44,7 @@ Page {
         PullDownMenu {
             MenuItem {
                 text: qsTr("Search artist image")
-                enabled: artist!==qsTr("Unknown artist") && artistcount==="1"
+                enabled: artist!==qsTr("Unknown artist")
                 onClicked: {
                     coversearch.clearData()
                     pageStack.push ("CoverDownload.qml", {"artist":artist, "searchingArtist":true, "album":""})

--- a/qml/pages/CoverArtList.qml
+++ b/qml/pages/CoverArtList.qml
@@ -66,7 +66,9 @@ BackgroundItem
     Connections {
         target: coversearch
         onImageChanged: {
-            if ((artist===dartist && album==dalbum) || (album===dartist && album==dalbum)) {
+            if ((artist===dartist && album==dalbum)
+                || (album===dartist && album==dalbum)
+                || (album===dartist && !dalbum)) {
                 console.log("Updated: " + artist + " - " + album)
                 reload()
             }
@@ -113,9 +115,9 @@ BackgroundItem
 
     Label {
         id: vtext
-        anchors.verticalCenter: coverImg.status!=Image.Error && textvisible? undefined : parent.verticalCenter
-        anchors.bottom: coverImg.status!=Image.Error && textvisible? parent.bottom : undefined
-        anchors.bottomMargin: coverImg.status!=Image.Error && textvisible? Theme.paddingSmall : undefined
+        y: coverImg.status!=Image.Error && textvisible
+            ? parent.height - height - Theme.paddingSmall
+            : (parent.height - height) / 2
         anchors.left: parent.left
         anchors.leftMargin: Theme.paddingMedium
         width: parent.width - Theme.paddingMedium*2

--- a/src/coversearch.cpp
+++ b/src/coversearch.cpp
@@ -2,6 +2,7 @@
 
 //#include <QDeclarativeView>
 #include <QDebug>
+#include <QDir>
 #include <QString>
 #include <QStringList>
 #include <QJsonDocument>
@@ -39,6 +40,9 @@ CoverSearch::CoverSearchPrivate::CoverSearchPrivate(CoverSearch * parent) : q(pa
     //q->pepe = new WebThread();
     //connect (q->pepe, SIGNAL(imgLoaded(QString,int)), parent, SLOT(paintImg(QString,int)) );
 
+    // Ensure that download destination exists.
+    QDir d;
+    d.mkpath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation));
 }
 
 CoverSearch::CoverSearchPrivate::~CoverSearchPrivate()

--- a/src/loadwebimage.cpp
+++ b/src/loadwebimage.cpp
@@ -158,9 +158,8 @@ void WebThread::checkAll()
     //QString url = "http://ws.audioscrobbler.com/2.0/?method=album.getinfo&api_key=7f338c7458e7d1a9a6204221ff904ba1";
 
     // QUASAR
-    QString url = "http://coverart.katastrophos.net/index.php?";
-    url += "&artist="+QUrl::toPercentEncoding(artist)+"&album="+QUrl::toPercentEncoding(album)+"&search=Search";
-
+    QString url = "https://coverart.katastrophos.net/query.php?";
+    url += "&artist="+QUrl::toPercentEncoding(artist)+"&album="+QUrl::toPercentEncoding(album)+"&mode=imageurls&limit=1";
 
  
     //AMAZON - SIMPLE
@@ -211,16 +210,9 @@ void WebThread::downloaded(QNetworkReply *respuesta)
 
             QString tmp = datos1;
 
-
             //QUASAR
-            if (tmp.contains("<ul title=\"Cover Arts\">"))
+            if (tmp.startsWith("http"))
             {
-                int x = tmp.indexOf("<li><a href=\"");
-                tmp.remove(0,x+13);
-                x = tmp.indexOf("\">");
-                tmp.remove(x,tmp.length()-x);
-                tmp = tmp.trimmed();
-
                 qDebug() << "Link for" << files[0][0] << files[0][1] << tmp;
 
                 downloadImage(tmp);


### PR DESCRIPTION
Close #30 

katastrofos.net is now using secure HTTP, replying with a 301 moved permanently when polled on HTTP only. This issue was making the album cover download not working.

Ensure that the cache directory for covers exists. This issue, introduced by #21, was making impossible to see downloaded covers and choose one, for an artist for instance.