### PR TITLE
Cease mentioning `taglib`

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -92,16 +92,6 @@ Page {
             }
 
             Label {
-                text: colored + qsTr("Taglib is used for reading, writing and manipulating audio file tags:") +
-                      "<br><a href='https://taglib.github.io/'>taglib.github.io</a>"
-                onLinkActivated: Qt.openUrlExternally(link)
-                font.pixelSize: Theme.fontSizeSmall
-                textFormat: Text.RichText
-                wrapMode: Text.WordWrap
-                width: parent.width
-            }
-
-            Label {
                 text: colored + qsTr("If you want to create a new translation or improve an extant one:") + "<br>" +
                       "<a href='https://app.transifex.com/olf/flowplayer/'>" + "Transifex - FlowPlayer</a>"
                 onLinkActivated: Qt.openUrlExternally(link)

--- a/translations/flowplayer.ts
+++ b/translations/flowplayer.ts
@@ -20,16 +20,11 @@
     </message>
     <message>
         <location filename="../qml/pages/AboutPage.qml" line="95"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/pages/AboutPage.qml" line="105"/>
         <source>If you want to create a new translation or improve an extant one:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="120"/>
+        <location filename="../qml/pages/AboutPage.qml" line="110"/>
         <source>You can support the original author of FlowPlayer by donating:</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
FlowPlayer's copy of `taglib` is long gone: See [commit 52dd4f0](https://github.com/sailfishos-applications/flowplayer/commit/52dd4f0168e7a2301da60345835cbf1ddc7cf459#diff-3438da7e1cea4985df356e817ea537f40f9c70bfe74e3131042c5ecbe44971cbR6).
<sub>This original change requires a SailfishOS release 1.0.? (`taglib` is definitely [already in before SFOS 2.0.2](https://together.jolla.com/question/139609/changelog-202-aurajoki/#139609-taglib) and no [earlier changelog](https://together.jolla.com/questions/scope:all/sort:age-desc/tags:changelog,official/) mentions `taglib` as a newly introduced package) or an externally provided `taglib`.</sub>