### PR TITLE
Try harder to get rid of hardcoded home paths

### DIFF
--- a/qml/pages/AddFolder.qml
+++ b/qml/pages/AddFolder.qml
@@ -31,7 +31,7 @@ Dialog {
         onAppendFilesDone: currentPath = path
     }
 
-    property string currentPath: "/home/nemo"
+    property string currentPath
 
     DialogHeader {
         id: header

--- a/qml/pages/AlbumListView.qml
+++ b/qml/pages/AlbumListView.qml
@@ -95,7 +95,7 @@ Page {
                     onClicked: {
                         helperList.clear()
                         myplaylistmanager.loadAlbum(model.artist, model.album, "1")
-                        meta.setFile(decodeURIComponent(helperList.get(0).url))
+                        meta.setFile(helperList.get(0).url)
                         helperList2.clear()
                         for ( var i=0; i<helperList.count; ++i )
                             helperList2.append(helperList.get(i))

--- a/qml/pages/AlbumMetadata.qml
+++ b/qml/pages/AlbumMetadata.qml
@@ -18,7 +18,7 @@ Dialog {
         //meta.setData(titleField.text, artistField.text, albumField.text, yearField.text)
         for ( var i=0; i<helperList2.count; ++i )
         {
-            meta.setFile(decodeURIComponent(helperList2.get(i).url),"false")
+            meta.setFile(helperList2.get(i).url,"false")
             console.log("TAG: " + artistField.text + " - " + albumField.text + " - " + yearField.text)
             meta.setAlbumData(artistField.text, albumField.text, yearField.text)
         }

--- a/qml/pages/NowPlaying.qml
+++ b/qml/pages/NowPlaying.qml
@@ -268,7 +268,7 @@ Page {
                     nppOpened = true
                     helperList2.clear()
                     helperList2.append({"url":bigCoverList.currentItem.myData.url})
-                    meta.setFile(decodeURIComponent(helperList2.get(0).url))
+                    meta.setFile(helperList2.get(0).url)
                     pageStack.push ("Metadata.qml", {"artist":bigCoverList.currentItem.myData.artist,
                                         "album":bigCoverList.currentItem.myData.album,
                                         "title":bigCoverList.currentItem.myData.title

--- a/qml/pages/SongsPage.qml
+++ b/qml/pages/SongsPage.qml
@@ -119,7 +119,7 @@ Page {
                     text: qsTr("Edit metadata")
                     onClicked: {
                         console.log("METADATA: " + model.url)
-                        meta.setFile(decodeURIComponent(model.url))
+                        meta.setFile(model.url)
                         pageStack.push ("Metadata.qml", {"artist": model.artist,
                                             "album": model.album,
                                             "title": model.title

--- a/src/meta.cpp
+++ b/src/meta.cpp
@@ -1,5 +1,6 @@
 #include "meta.h"
 #include <QFileInfo>
+#include <QUrl>
 
 #include <mpegfile.h>
 #include <flacfile.h>
@@ -27,14 +28,15 @@ Meta::Meta(QQuickItem *parent)
 
 void Meta::setFile(QString file, QString update)
 {
+    QString path = file.startsWith(QString::fromLatin1("file://")) ? QUrl(file).toLocalFile() : file;
     //QString f = file.remove("file://");
     //tagFile = new TagLib::FileRef(f.toUtf8());
 
-    TagLib::File* tf = getFileByMimeType(file.remove("file://"));
+    TagLib::File* tf = getFileByMimeType(path);
 
     if(!tf) return;
 
-    currentFile = reemplazar1(file.remove("file://"));
+    currentFile = reemplazar1(path);
 
     tagFile = new TagLib::FileRef(tf);
 
@@ -44,7 +46,7 @@ void Meta::setFile(QString file, QString update)
         m_album = QString::fromUtf8(tagFile->tag()->album().toCString(true));
         m_artist = QString::fromUtf8(tagFile->tag()->artist().toCString(true));
         m_year = QString::number(tagFile->tag()->year());
-        m_filename = QFileInfo(file.remove("file://")).filePath().remove("/home/nemo/"); + "/" + QFileInfo(file.remove("file://")).fileName();
+        m_filename = path;
         emit dataChanged();
     }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -647,6 +647,9 @@ void Utils::getFolderItemsUp(QString path)
 
 void Utils::getFolderItems(QString path)
 {
+    if (path.isEmpty()) {
+        path = QDir::homePath();
+    }
     qDebug() << "Loading folder: " << path;
 
     if (!QFileInfo(path).exists())


### PR DESCRIPTION
Should fix #47 .

The only matchs that remain, are within commented parts of the code in `src/utils.cpp` and `src/playlist.cpp`. There is also a lone match in `extras/LockScreen.qml` but this file seems to duplicate an ancient version of the Jolla LockScreen.qml. I don't think it's a good idea to try to do anything with it now.