### PR TITLE
Change the organisation name

### DIFF
--- a/src/FlowPlayer.cpp
+++ b/src/FlowPlayer.cpp
@@ -28,13 +28,13 @@ int main(int argc, char *argv[])
     QTextCodec::setCodecForLocale(linuxCodec);
 
     QGuiApplication *app = SailfishApp::application(argc, argv);
-    app->setOrganizationName("flowplayer");
+    app->setOrganizationName("sailfishos-applications");
     app->setApplicationName("flowplayer");
 
     QString lang;
     QTranslator translator;
 
-    QSettings settings("cepiperez", "flowplayer");
+    QSettings settings;
     lang = settings.value("Language", "undefined").toString();
 
     if (lang=="undefined")

--- a/src/FlowPlayer.cpp
+++ b/src/FlowPlayer.cpp
@@ -22,6 +22,61 @@
 bool isDBOpened;
 bool databaseWorking;
 
+static void migrateSettings()
+{
+    const QString oldSettings = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/cepiperez/flowplayer.conf";
+    const QString newSettings = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + ".conf";
+    if (QFile::exists(oldSettings)) {
+        if (QDir().mkpath(QFileInfo(newSettings).path())
+            && !QFile::rename(oldSettings, newSettings)) {
+            qWarning() << "unable to move old configuration from" << oldSettings << "to" << newSettings;
+        }
+        QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)).rmdir("cepiperez");
+    }
+}
+
+static void migrateDatabase()
+{
+    const QString olderDb = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/cepiperez/flowplayer.db";
+    const QString oldDb = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/flowplayer/flowplayer/flowplayer.db";
+    const QString newDb = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.db";
+    if (QFile::exists(oldDb)) {
+        if (QDir().mkpath(QFileInfo(newDb).path())
+            && !QFile::rename(oldDb, newDb)) {
+            qWarning() << "unable to move old database from" << oldDb << "to" << newDb;
+        }
+        QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/flowplayer").rmdir("flowplayer");
+        QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)).rmdir("flowplayer");
+    } else if (QFile::exists(olderDb)) {
+        if (QDir().mkpath(QFileInfo(newDb).path())
+            && !QFile::rename(olderDb, newDb)) {
+            qWarning() << "unable to move old database from" << olderDb << "to" << newDb;
+        }
+        QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)).rmdir("cepiperez");
+    }
+}
+
+static void migrateCache()
+{
+    const QString olderCache = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/flowplayer";
+    const QString oldCache = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/flowplayer/flowplayer";
+    const QString newCache = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (QFileInfo(oldCache).isDir()) {
+        if (QDir().mkpath(QFileInfo(newCache).path())
+            && !QDir().rename(oldCache, newCache)) {
+            qWarning() << "unable to move old cache from" << oldCache << "to" << newCache;
+        }
+        QDir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/flowplayer").rmdir("flowplayer");
+        QDir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)).rmdir("flowplayer");
+    } else if (QFileInfo(olderCache).isDir()) {
+        if (QDir().mkpath(QFileInfo(newCache).path())
+            && !QDir().rename(olderCache, newCache)) {
+            qWarning() << "unable to move old cache from" << olderCache << "to" << newCache;
+        }
+        QDir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)).rmdir("flowplayer");
+    }
+}
+
 int main(int argc, char *argv[])
 {
     QTextCodec *linuxCodec = QTextCodec::codecForName("UTF-8");
@@ -30,6 +85,10 @@ int main(int argc, char *argv[])
     QGuiApplication *app = SailfishApp::application(argc, argv);
     app->setOrganizationName("sailfishos-applications");
     app->setApplicationName("flowplayer");
+
+    migrateSettings();
+    migrateDatabase();
+    migrateCache();
 
     QString lang;
     QTranslator translator;

--- a/src/coversearch.cpp
+++ b/src/coversearch.cpp
@@ -165,7 +165,7 @@ void CoverSearch::remove(const QString &file)
     QString nf = file;
     if ( nf.startsWith("//") )
         nf.remove(0, 1);
-    QSettings settings("cepiperez", "flowplayer");
+    QSettings settings;
     QStringList entries = settings.value("CoverSearch","").toStringList();
     QStringList newfiles;
     for (int i=0; i< entries.count(); ++i)

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -237,7 +237,7 @@ void DataReader::run()
     favFiles.clear();
     map.clear();
 
-    QSettings settings("cepiperez", "flowplayer");
+    QSettings settings;
     QStringList folders = settings.value("Folders","").toString().split("<separator>");
     folders.removeAll("");
 

--- a/src/datos.cpp
+++ b/src/datos.cpp
@@ -233,7 +233,7 @@ void Datos::addFilterToQueue()
     }*/
 
     QString norder;
-    QSettings settings("cepiperez", "flowplayer");
+    QSettings settings;
     QString order = settings.value("TrackOrder", "title").toString();
 
     if (order=="title") norder="title";
@@ -429,7 +429,7 @@ QString Datos::getArtistsCovers()
             dato1.append(coverart);
     }
 
-    QSettings settings("cepiperez", "flowplayer");
+    QSettings settings;
     int first = settings.value("LastArtistItem", 0).toInt();
 
     if (first >= dato1.count()) {
@@ -463,7 +463,7 @@ QString Datos::getAlbumsCovers()
             dato1.append(coverart);
     }
 
-    QSettings settings("cepiperez", "flowplayer");
+    QSettings settings;
     int first = settings.value("LastAlbumItem", 0).toInt();
 
     if (first >= dato1.count()) {

--- a/src/lfm.cpp
+++ b/src/lfm.cpp
@@ -31,7 +31,7 @@ LFM::LFM(QQuickItem *parent)
     //connect(datos5, SIGNAL(finished(QNetworkReply*)), this, SLOT(downloaded5(QNetworkReply*)));
     //connect(datos6, SIGNAL(finished(QNetworkReply*)), this, SLOT(downloaded6(QNetworkReply*)));
 
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     lang = sets.value("LastFMlang", "en").toString();
 }
 
@@ -277,7 +277,7 @@ void LFM::getBio(QString artist)
 
     //if ( reply1 && reply1->isRunning() )
     //    reply1->abort();
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     lang = sets.value("Language", "en").toString();
     artistInfo = tr("Fetching artist information");
     artistInfoLarge = "";
@@ -301,7 +301,7 @@ void LFM::getAlbumBio(QString artist, QString album)
 {
     /*if ( reply2 && reply2->isRunning() )
         reply2->abort();
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     lang = sets.value("LastFMlang", "en").toString();
     albumInfo = tr("Fetching album information");
     albumInfoLarge = "";
@@ -316,7 +316,7 @@ void LFM::getSongBio(QString artist, QString song)
 {
     /*if ( reply3 && reply3->isRunning() )
         reply3->abort();
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     lang = sets.value("LastFMlang", "en").toString();
     songInfo = tr("Fetching track information");
     songInfoLarge = "";

--- a/src/musicmodel.cpp
+++ b/src/musicmodel.cpp
@@ -57,7 +57,7 @@ void MusicModel::loadData(QString artist, QString album, QString various)
 
     if (!isDBOpened) openDatabase();
 
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     QString torder = sets.value("TrackOrder", "title").toString();
     QString order;
     if (torder=="title") order="title";

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -20,7 +20,7 @@ static gboolean bus_cb (GstBus *bus, GstMessage *msg, gpointer data)
 static void prepare_next_stream(GstElement *obj, gpointer data) {
     qDebug() << "ABOUT TO FINISH";
 
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     if (sets.value("GaplessPlayback", "no").toString()=="no")
         return;
 
@@ -421,7 +421,7 @@ void Player::backend_deinit()
 void Player::setEq(bool enabled)
 {
     qDebug() << "Setting eq: " << enabled;
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     sets.setValue("Equalizer", enabled? "Yes" : "No");
     sets.sync();
 
@@ -472,7 +472,7 @@ void Player::setEqualizerReal(int band, int value)
 
 void Player::loadEqualizer()
 {
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     m_eqenabled = sets.value("Equalizer", "No").toString()=="Yes";
     emit eqEnabledChanged();
 

--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -5,7 +5,7 @@
 #include <QXmlStreamReader>
 #include <QDir>
 
-QSettings sets("cepiperez", "flowplayer");
+QSettings sets;
 QList<int> randomlist;
 int currentItem, currentRandom;
 

--- a/src/playlistmanager.cpp
+++ b/src/playlistmanager.cpp
@@ -8,8 +8,6 @@
 extern bool databaseWorking;
 extern bool isDBOpened;
 
-QSettings pmsets("cepiperez", "flowplayer");
-
 PlaylistManager::PlaylistManager(QQuickItem *parent)
     : QQuickItem(parent)
 {
@@ -91,7 +89,7 @@ void PlaylistManager::addAlbumToList(QString list, QString artist, QString album
 
     if (!isDBOpened) openDatabase();
 
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     QString torder = sets.value("TrackOrder", "title").toString();
     QString order;
     if (torder=="title") order="title";
@@ -433,7 +431,7 @@ void PlaylistManager::loadAlbum(QString artist, QString album, QString various)
 
     if (!isDBOpened) openDatabase();
 
-    QSettings sets("cepiperez", "flowplayer");
+    QSettings sets;
     QString torder = sets.value("TrackOrder", "title").toString();
     QString order;
     if (torder=="title") order="title";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,7 +12,7 @@ QString albumArtUrl, albumArtArtist, albumArtAlbum;
 QString currentArtist, currentSong;
 QString searchServer;
 
-QSettings settings("cepiperez", "flowplayer");
+QSettings settings;
 
 //extern bool isDBOpened;
 


### PR DESCRIPTION
Change the organisation name to `sailfishos-applications`. Also change the QSettings objects to use the application organisation name.

Add some code to automatically migrate the data from the old directories to the new ones, defined by #21 and by changing the organisation name.

This should fix #50.

Before accepting this MR, we need to agree on the organisation name. Your proposition to use the github location looks fine. I'm just wondering if the code would be used one day outside of Sailfish (need to rewrite the UI, I know...), does this organisation name still makes sense ? Migration code are a bit error prone to write :-/