### PR TITLE
Remove `migrating-to-v0.3.x.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **FlowPlayer is a music player with lyrics support, online radio and 10-band equalizer.**
 
-Features:
+<br />
+
+#### Features:
 - *<ToDo: A pull request for [the README.md](https://github.com/sailfishos-applications/flowplayer/blob/devel/README.md) which provides a list of features will be much appreciated.>*
 
 <sup>Note that the ability to ... may be broken (this is [known for XXX](https://github.com/sailfishos-applications/flowplayer/issues/) ‒ currently nothing) due to API changes in recent SailfishOS releases.</sup><br />
@@ -28,12 +30,6 @@ If you want to translate FlowPlayer to a language it does not support yet or imp
 | ![Covers by artist](./.xdata/screenshots/screenshot-20150711134206.jpg?raw=true) | ![Playlists](./.xdata/screenshots/screenshot-20150711134443.jpg?raw=true) | ![FileCase's cover](./.xdata/screenshots/screenshot-20150711134615.jpg?raw=true) | ![Lyrics](./.xdata/screenshots/screenshot-20150701221204.jpg?raw=true)
 | &nbsp;&nbsp;Covers&nbsp;by&nbsp;artist&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Playlists&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | FlowPlayer's&nbsp;cover | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Lyrics&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |
 |       |       |       |       |
-<br />
-
-## Migrating from FlowPlayer 0.1.x / 0.2.x to 0.3.x
-
-A [draft of a migration guide](./migrating-to-v0.3.x.md) was contributed; PRs to enhance it are very welcome.
-
 <br />
 
 ## History of FlowPlayer

--- a/migrating-to-v0.3.x.md
+++ b/migrating-to-v0.3.x.md
@@ -1,7 +1,0 @@
-<sub>Reported by user @Ahtisilli at [Forum SailishOS Org (FSO)](https://forum.sailfishos.org/t/reviving-cepiperezs-flowplayer/17532/18?u=olf).</sub>
-
-#### Xperia XA2 (32-bit)
-Migrating from v0.1.x / v0.2.x version was a piece of cake: After starting and closing the new version (to see where the new file locations are), move/copy/symlink the configuration and database files from `~/.config/cepiperez/` to `~/.config/flowplayer/flowplayer/` and move the files in `~/.cache/flowplayer/` to `~/.cache/flowplayer/flowplayer`. For some reason the active configuration file is now in `cepiperez` and the active database in `flowplayer`.
-
-#### Xperia 10 III (64-bit)
-After a successful migration from 32-bit nemo to 64-bit defaultuser, I used `rsync -rtuv` over WiFi to copy FlowPlayer's files and the media-art cache (slow but elegant) and created symlinks so that the paths match - maybe I should look into SQLite3 to be able to fix the paths…


### PR DESCRIPTION
Obsoleted by commit 1802118:
**[Add some migration code for the data](https://github.com/sailfishos-applications/flowplayer/commit/1802118737a56ac1c0ae7e0a6b2d3f9fce7175c0)**
Move the cache, settings and database from
the old locations to the new ones.