### PR TITLE
Don't use static QSettings in playlist.cpp

### DIFF
--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -5,7 +5,6 @@
 #include <QXmlStreamReader>
 #include <QDir>
 
-QSettings sets;
 QList<int> randomlist;
 int currentItem, currentRandom;
 
@@ -25,12 +24,14 @@ int Playlist::current()
 
 QString Playlist::active() const
 {
+    QSettings sets;
     QString t = sets.value("Active", "false").toString();
     return t;
 }
 
 QString Playlist::unknown() const
 {
+    QSettings sets;
     QString t = sets.value("Unknown", "false").toString();
     return t;
 }
@@ -415,6 +416,7 @@ void Playlist::changeUnknown(bool active)
 {
     //qDebug() << "CHANGING UKNOWN: " << active;
 
+    QSettings sets;
     sets.setValue("Unknown", active);
     sets.sync();
 }
@@ -423,6 +425,7 @@ void Playlist::changeMode(QString mode)
 {
     //qDebug() << "CHANGING MODE: " << mode;
 
+    QSettings sets;
     sets.setValue("Mode", mode);
     sets.sync();
 }


### PR DESCRIPTION
I don't think this object is still actively used in the code, but for consistency sake (and not to leave any non-fonctional code I created), I'm following #65 in `playlist.cpp` also.