### PR TITLE
[Feature] Add local cover art when importing tracks

### DIFF
--- a/flowplayer.desktop
+++ b/flowplayer.desktop
@@ -6,4 +6,8 @@ Exec=flowplayer
 Name=FlowPlayer
 
 [X-Sailjail]
-Sandboxing=Disabled
+OrganizationName=sailfishos-applications
+# ApplicationName does not have to be identical to Name
+ApplicationName=flowplayer
+# Add the required permissions here
+Permissions=UserDirs;Audio;MediaIndexing;Bluetooth;Internet;RemovableMedia

--- a/flowplayer.desktop
+++ b/flowplayer.desktop
@@ -10,4 +10,4 @@ OrganizationName=sailfishos-applications
 # ApplicationName does not have to be identical to Name
 ApplicationName=flowplayer
 # Add the required permissions here
-Permissions=UserDirs;Audio;MediaIndexing;Bluetooth;Internet;RemovableMedia
+Permissions=UserDirs;Audio;Bluetooth;Internet;RemovableMedia

--- a/src/FlowPlayer.cpp
+++ b/src/FlowPlayer.cpp
@@ -75,11 +75,6 @@ static void migrateCache()
         }
         QDir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)).rmdir("flowplayer");
     }
-    // if the media-art directory does not exist, make it.
-    if (!QFileInfo(newCache).isDir()) {
-        QDir().mkpath( newCache );
-        QDir().mkpath( newCache + "/media-art" );
-    }
 }
 
 int main(int argc, char *argv[])
@@ -118,6 +113,9 @@ int main(int argc, char *argv[])
 
     app->installTranslator(&translator);
 
+    // ensure the media cache dir is created
+    const QString mediaCacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art";
+    QDir().mkpath( mediaCacheDir );
 
     QScopedPointer<QQuickView> window(SailfishApp::createView());
     window->setTitle("FlowPlayer");

--- a/src/FlowPlayer.cpp
+++ b/src/FlowPlayer.cpp
@@ -75,6 +75,11 @@ static void migrateCache()
         }
         QDir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)).rmdir("flowplayer");
     }
+    // if the media-art directory does not exist, make it.
+    if (!QFileInfo(newCache).isDir()) {
+        QDir().mkpath( newCache );
+        QDir().mkpath( newCache + "/media-art" );
+    }
 }
 
 int main(int argc, char *argv[])

--- a/src/coversearch.cpp
+++ b/src/coversearch.cpp
@@ -357,7 +357,7 @@ void CoverSearch::paintImg(QString image, int index)
 
 void CoverSearch::saveImage(QString artist, QString album, QString imagepath)
 {
-    QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+    QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
 
     QImage image(imagepath);
     image.save(th2, "JPEG");

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -20,7 +20,6 @@
 #include <xmfile.h>
 
 
-#include <QCryptographicHash>
 #include <QDir>
 #include <QDirIterator>
 #include <QString>
@@ -211,23 +210,21 @@ void DataReader::readFile(QString file)
             // if we have artist and album, we check for a cover image.
             if (m_artist != "" && m_album != "") {
                 QFileInfo info(file);
-                QDirIterator iterator(info.dir().path(), QDirIterator::Subdirectories);
+                QDirIterator iterator(info.dir());
                 while (iterator.hasNext()) {
                     iterator.next();
-                    // we are explicit about two common factors, the suffix `jpeg` (ToDo: add `jpg` and `png`
+                    // we are explicit about two common factors, the type JPEG (ToDo: add PNG
                     // throughout all C++ source files, see issue #78), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
-                        if (  iterator.fileInfo().suffix() == "jpeg" &&
-                              // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" ||
+                        if (  (iterator.fileInfo().suffix() == "jpeg" ||
+                               iterator.fileInfo().suffix() == "jpg") &&
+                              // See ToDo above: (… ||
                               //                  iterator.fileInfo().suffix() == "png") &&
                               (iterator.fileInfo().baseName() == "cover" ||
-                               iterator.fileInfo().baseName() == "folder")
-                           )
-                        {
+                               iterator.fileInfo().baseName() == "folder")  ) {
                             QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
-                                          "/media-art/album-" + doubleHash(m_artist, m_album) +
-                                          iterator.fileInfo().suffix();
-                            qDebug() << "PROCESSING FILE: " << iterator.filePath();
+                                          "/media-art/album-" + doubleHash(m_artist, m_album) + ".jpeg";
+                            qDebug() << "COPYING FILE ART: " << iterator.filePath() << m_artist << m_album;
                             QFile::copy(iterator.filePath(), th2);
                         }
                     }

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -227,7 +227,7 @@ void DataReader::readFile(QString file)
                             QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
                                           "/media-art/album-" + doubleHash(m_artist, m_album) +
                                           iterator.fileInfo().suffix();
-                            qDebug() << "PROCESSING FILE: " << iterator.filePath() ;
+                            qDebug() << "PROCESSING FILE: " << iterator.filePath();
                             QFile::copy(iterator.filePath(), th2);
                         }
                     }

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -215,7 +215,7 @@ void DataReader::readFile(QString file)
                 while (iterator.hasNext()) {
                     iterator.next();
                     // we are explicit about two common factors, the suffix .jpeg (ToDo: add .jpg and .png
-                    //  throughout all source code), and basename cover or folder
+                    // throughout all C++ source code files), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  iterator.fileInfo().suffix() == "jpeg" &&
                               // (… || iterator.fileInfo().suffix() == "jpg" || iterator.fileInfo().suffix() == "png") &&

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -215,9 +215,15 @@ void DataReader::readFile(QString file)
                 QDirIterator iterator(info.dir().path(), QDirIterator::Subdirectories);
                 while (iterator.hasNext()) {
                     iterator.next();
-                    if (!iterator.fileInfo().isDir()) {
-                        if (  iterator.filePath().toLower().endsWith(".jpg") ||
-                              iterator.filePath().toLower().endsWith(".jpeg") )
+                    // we are explicit about two common factors,
+                    // suffix jpg or png, basename cover or folder
+                    if (iterator.fileInfo().isFile()) {
+                        if (  ( iterator.fileInfo().suffix() == "jpg"  ||
+                                iterator.fileInfo().suffix() == "jpeg" ||
+                                iterator.fileInfo().suffix() == "png"     )   &&
+                              ( iterator.fileInfo().baseName() == "cover" ||
+                                iterator.fileInfo().baseName() == "folder" )
+                              )
                         {
                             QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(m_artist, m_album) + ".jpeg";
                             qDebug() << "PROCESSING FILE: " << iterator.filePath() ;

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -214,16 +214,17 @@ void DataReader::readFile(QString file)
                 QDirIterator iterator(info.dir().path(), QDirIterator::Subdirectories);
                 while (iterator.hasNext()) {
                     iterator.next();
-                    // we are explicit about two common factors, the suffix .jpeg (ToDo: add .jpg and .png
-                    // throughout all C++ source code files), and basename cover or folder
+                    // we are explicit about two common factors, the suffix `jpeg` (ToDo: add `jpg` and `png`
+                    // throughout all C++ source files), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  iterator.fileInfo().suffix() == "jpeg" &&
-                              // (… || iterator.fileInfo().suffix() == "jpg" || iterator.fileInfo().suffix() == "png") &&
+                              // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" || iterator.fileInfo().suffix() == "png") &&
                               (iterator.fileInfo().baseName() == "cover" ||
                                iterator.fileInfo().baseName() == "folder")
                            )
                         {
-                            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(m_artist, m_album) + iterator.fileInfo().suffix();
+                            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + \
+                                          "/media-art/album-" + doubleHash(m_artist, m_album) + iterator.fileInfo().suffix();
                             qDebug() << "PROCESSING FILE: " << iterator.filePath() ;
                             QFile::copy(iterator.filePath(), th2);
                         }

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -218,7 +218,7 @@ void DataReader::readFile(QString file)
                     // suffix jpg or png, basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  ( iterator.fileInfo().suffix() == "jpg"  ||
-                                iterator.fileInfo().suffix() == "jpeg" || ) &&
+                                iterator.fileInfo().suffix() == "jpeg" ) &&
                               ( iterator.fileInfo().baseName() == "cover" ||
                                 iterator.fileInfo().baseName() == "folder" )
                               )

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -215,7 +215,7 @@ void DataReader::readFile(QString file)
                 while (iterator.hasNext()) {
                     iterator.next();
                     // we are explicit about two common factors, the suffix `jpeg` (ToDo: add `jpg` and `png`
-                    // throughout all C++ source files), and basename cover or folder
+                    // throughout all C++ source files, see issue #78), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  iterator.fileInfo().suffix() == "jpeg" &&
                               // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" ||

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -214,16 +214,16 @@ void DataReader::readFile(QString file)
                 QDirIterator iterator(info.dir().path(), QDirIterator::Subdirectories);
                 while (iterator.hasNext()) {
                     iterator.next();
-                    // we are explicit about two common factors,
-                    // suffix jpg or png, basename cover or folder
+                    // we are explicit about two common factors, the suffix .jpeg (ToDo: add .jpg and .png
+                    //  throughout all source code), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
-                        if (  ( iterator.fileInfo().suffix() == "jpg"  ||
-                                iterator.fileInfo().suffix() == "jpeg" ) &&
-                              ( iterator.fileInfo().baseName() == "cover" ||
-                                iterator.fileInfo().baseName() == "folder" )
-                              )
+                        if (  iterator.fileInfo().suffix() == "jpeg" &&
+                              // (… || iterator.fileInfo().suffix() == "jpg" || iterator.fileInfo().suffix() == "png") &&
+                              (iterator.fileInfo().baseName() == "cover" ||
+                               iterator.fileInfo().baseName() == "folder")
+                           )
                         {
-                            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(m_artist, m_album) + ".jpeg";
+                            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(m_artist, m_album) + iterator.fileInfo().suffix();
                             qDebug() << "PROCESSING FILE: " << iterator.filePath() ;
                             QFile::copy(iterator.filePath(), th2);
                         }

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -219,8 +219,7 @@ void DataReader::readFile(QString file)
                     // suffix jpg or png, basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  ( iterator.fileInfo().suffix() == "jpg"  ||
-                                iterator.fileInfo().suffix() == "jpeg" ||
-                                iterator.fileInfo().suffix() == "png"     )   &&
+                                iterator.fileInfo().suffix() == "jpeg" || ) &&
                               ( iterator.fileInfo().baseName() == "cover" ||
                                 iterator.fileInfo().baseName() == "folder" )
                               )

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -218,13 +218,15 @@ void DataReader::readFile(QString file)
                     // throughout all C++ source files), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  iterator.fileInfo().suffix() == "jpeg" &&
-                              // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" || iterator.fileInfo().suffix() == "png") &&
+                              // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" || \
+                              //                  iterator.fileInfo().suffix() == "png") &&
                               (iterator.fileInfo().baseName() == "cover" ||
                                iterator.fileInfo().baseName() == "folder")
                            )
                         {
                             QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + \
-                                          "/media-art/album-" + doubleHash(m_artist, m_album) + iterator.fileInfo().suffix();
+                                          "/media-art/album-" + doubleHash(m_artist, m_album) + \
+                                          iterator.fileInfo().suffix();
                             qDebug() << "PROCESSING FILE: " << iterator.filePath() ;
                             QFile::copy(iterator.filePath(), th2);
                         }

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -218,14 +218,14 @@ void DataReader::readFile(QString file)
                     // throughout all C++ source files), and basename cover or folder
                     if (iterator.fileInfo().isFile()) {
                         if (  iterator.fileInfo().suffix() == "jpeg" &&
-                              // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" || \
+                              // See ToDo above: (… || iterator.fileInfo().suffix() == "jpg" ||
                               //                  iterator.fileInfo().suffix() == "png") &&
                               (iterator.fileInfo().baseName() == "cover" ||
                                iterator.fileInfo().baseName() == "folder")
                            )
                         {
-                            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + \
-                                          "/media-art/album-" + doubleHash(m_artist, m_album) + \
+                            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
+                                          "/media-art/album-" + doubleHash(m_artist, m_album) +
                                           iterator.fileInfo().suffix();
                             qDebug() << "PROCESSING FILE: " << iterator.filePath() ;
                             QFile::copy(iterator.filePath(), th2);

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -187,6 +187,8 @@ TagLib::File* DataReader::getFileByMimeType(QString file)
 
 void DataReader::readFile(QString file)
 {
+    // Is oFile used somewhere? (I failed to find a location.)
+    // If not, what is this new line good for?  For details, see PR #75.
     QString oFile = file;
 
     file.remove("file://");

--- a/src/datos.cpp
+++ b/src/datos.cpp
@@ -29,7 +29,7 @@ bool namefileLessThan(const QStringList &d1, const QStringList &d2)
 
 QString Datos::getThumbnail(QString data, int index)
 {
-    QString th1 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ data + ".jpeg";
+    QString th1 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ data + ".jpeg";
 
     /*QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/flowplayer/62/album-"+ data + ".jpeg";
 
@@ -320,7 +320,7 @@ void Datos::DatosPrivate::populateItems()
                 item->band = q->listado[i][3];
                 item->songs = q->listado[i][4];
                 item->hash = doubleHash(item->acount=="1"? item->artist : item->title, item->title);
-                item->coverart = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ item->hash + ".jpeg";
+                item->coverart = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ item->hash + ".jpeg";
                 item->isSelected = false;
             } else if (groupFilter=="artist") {
                 item->artist = q->listado[i][1]=="1"? tr("1 album") : tr("%1 albums").arg( q->listado[i][1].toInt());

--- a/src/loadwebimage.cpp
+++ b/src/loadwebimage.cpp
@@ -80,7 +80,7 @@ bool WebThread::checkInternal()
 
         if (QFileInfo(dir + "/folder.jpg").exists())
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
             QImage image(dir + "/folder.jpg");
             image.save(th2, "JPEG");
             emit imgLoaded(th2, files[0][2].toInt());
@@ -89,7 +89,7 @@ bool WebThread::checkInternal()
 
         else if (QFileInfo(dir + "/folder.jpeg").exists())
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
             QImage image(dir + "/folder.jpeg");
             image.save(th2, "JPEG");
             emit imgLoaded(th2, files[0][2].toInt());
@@ -98,7 +98,7 @@ bool WebThread::checkInternal()
 
         else if (QFileInfo(dir + "/cover.jpg").exists())
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
             QImage image(dir + "/cover.jpg");
             image.save(th2, "JPEG");
             emit imgLoaded(th2, files[0][2].toInt());
@@ -107,7 +107,7 @@ bool WebThread::checkInternal()
 
         if (QFileInfo(dir + "/Folder.jpg").exists())
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
             QImage image(dir + "/Folder.jpg");
             image.save(th2, "JPEG");
             emit imgLoaded(th2, files[0][2].toInt());
@@ -116,7 +116,7 @@ bool WebThread::checkInternal()
 
         else if (QFileInfo(dir + "/Folder.jpeg").exists())
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
             QImage image(dir + "/Folder.jpeg");
             image.save(th2, "JPEG");
             emit imgLoaded(th2, files[0][2].toInt());
@@ -125,7 +125,7 @@ bool WebThread::checkInternal()
 
         else if (QFileInfo(dir + "/Cover.jpg").exists())
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(artist, album) + ".jpeg";
             QImage image(dir + "/Cover.jpg");
             image.save(th2, "JPEG");
             emit imgLoaded(th2, files[0][2].toInt());
@@ -292,7 +292,7 @@ QString WebThread::saveToDisk(QIODevice *reply)
 
     QString art = files[0][0];
     QString alb = files[0][1];
-    QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(art, alb) + ".jpeg";
+    QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(art, alb) + ".jpeg";
 
     QImage image = QImage::fromData(reply->readAll());
     image.save(th2, "JPEG");
@@ -304,7 +304,7 @@ QString WebThread::saveToDiskExtern(QIODevice *reply)
 {
     QImage image = QImage::fromData(reply->readAll());
 
-    QString path = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/flowplayer/" + hash(curImage) + ".jpeg";
+    QString path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/flowplayer/" + hash(curImage) + ".jpeg";
 
     image.save(path, "JPEG");
 

--- a/src/missing.cpp
+++ b/src/missing.cpp
@@ -78,10 +78,10 @@ void Missing::loadData()
 
         if (dato1!=tr("Unknown album") && dato2!=tr("Unknown artist"))
         {
-            QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(dato2, dato1) + ".jpeg";
+            QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(dato2, dato1) + ".jpeg";
             if ( ! QFileInfo(th2).exists() )
             {
-                QString th3 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(dato1, dato1); + ".jpeg";
+                QString th3 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(dato1, dato1); + ".jpeg";
                 if ( ! QFileInfo(th3).exists() )
                 {
                     //qDebug() << dato1 << " doesn't exist. Adding to list";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -83,7 +83,7 @@ void Utils::readLyrics(QString artist, QString song)
     QString sng = cleanItem(song);
     if ( ( art!="" ) && ( sng!="" ) )
     {
-        QString th1 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/lyrics/"+art+"-"+sng+".txt";
+        QString th1 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lyrics/"+art+"-"+sng+".txt";
 
         if ( QFileInfo(th1).exists() )
         {
@@ -116,10 +116,10 @@ QString Utils::thumbnail(QString artist, QString album, QString count)
     QString art = count=="1"? artist : album;
     QString alb = album;
 
-    QString th1 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(art, alb) + ".jpeg";
+    QString th1 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(art, alb) + ".jpeg";
 
     if (!QFileInfo(th1).exists()) {
-        QString th2 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-"+ doubleHash(alb, alb) + ".jpeg";
+        QString th2 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-"+ doubleHash(alb, alb) + ".jpeg";
         if (QFileInfo(th2).exists())
             return th2;
     }
@@ -355,11 +355,11 @@ void Utils::downloaded(QNetworkReply *respuesta)
 void Utils::saveLyrics(QString artist, QString song, QString lyrics)
 {
     QDir d;
-    d.mkdir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/lyrics");
+    d.mkdir(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lyrics");
 
     QString art = cleanItem(artist);
     QString sng = cleanItem(song);
-    QString f = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/lyrics/"+art+"-"+sng+".txt";
+    QString f = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lyrics/"+art+"-"+sng+".txt";
 
     if ( QFileInfo(f).exists() )
         QFile::remove(f);
@@ -377,11 +377,11 @@ void Utils::saveLyrics(QString artist, QString song, QString lyrics)
 void Utils::saveLyrics2(QString artist, QString song, QString lyrics)
 {
     QDir d;
-    d.mkdir(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/lyrics");
+    d.mkdir(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lyrics");
 
     QString art = cleanItem(artist);
     QString sng = cleanItem(song);
-    QString f = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/lyrics/"+art+"-"+sng+".txt";
+    QString f = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lyrics/"+art+"-"+sng+".txt";
 
     if ( QFileInfo(f).exists() )
         QFile::remove(f);
@@ -421,10 +421,10 @@ void Utils::Finished(int requestId, bool)
             QImage img;
             img.loadFromData(bytes);
 
-            QString th1 = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/album-" + doubleHash(albumArtArtist, albumArtAlbum) + ".jpeg";
-            if ( QFileInfo(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/preview.jpeg").exists() )
+            QString th1 = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/album-" + doubleHash(albumArtArtist, albumArtAlbum) + ".jpeg";
+            if ( QFileInfo(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/preview.jpeg").exists() )
                 removePreview();
-            img.save(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/preview.jpeg");
+            img.save(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/preview.jpeg");
             downloadedAlbumArt = th1;
             emit coverDownloaded();
         }
@@ -434,7 +434,7 @@ void Utils::Finished(int requestId, bool)
 
 void Utils::removePreview()
 {
-    QFile f(QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/media-art/preview.jpeg");
+    QFile f(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/media-art/preview.jpeg");
     f.remove();
 }
 

--- a/translations/ca.ts
+++ b/translations/ca.ts
@@ -9,19 +9,24 @@
         <translation>Quant a</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>S&apos;utilitza Taglib per llegir, escriure i manipular etiquetes dels fitxers d&apos;àudio</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Si el vostre idioma no està disponible podeu contribuir aquí:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Podeu contribuir a mantenir aquest projecte actiu fent una petita donació</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -221,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Artista desconegut</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Àlbum desconegut</translation>
     </message>
@@ -234,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Artistes diversos</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 àlbum</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 àlbums</translation>
     </message>
@@ -335,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Error en l&apos;obtenció de la informació de l&apos;artista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>No s&apos;ha pogut trobar l&apos;artista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Error en l&apos;obtenció de la informació de l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>No s&apos;ha pogut trobar l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>No s&apos;ha trobat informació de l&apos;àlbum</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Error en l&apos;obtenció de la informació de la pista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>No s&apos;ha pogut trobar la pista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>No s&apos;ha trobat informació de la pista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>S&apos;està obtenint la informació de l&apos;artista</translation>
     </message>
@@ -614,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Artista desconegut</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Àlbum desconegut</translation>
     </message>
@@ -674,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Artistes diversos</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Àlbum desconegut</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Artista desconegut</translation>
     </message>
@@ -706,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Artista desconegut</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Àlbum desconegut</translation>
     </message>
@@ -844,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Selecciona una carpeta</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Artista desconegut</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Àlbum desconegut</translation>
     </message>
@@ -859,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Personalitza les llistes de reproducció</translation>
     </message>

--- a/translations/ca.ts
+++ b/translations/ca.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Artista desconegut</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Àlbum desconegut</translation>
     </message>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Ukendt kunstner</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Ukendt album</translation>
     </message>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -9,19 +9,24 @@
         <translation>Om</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>TagLib bruges til at læse, skrive og manipulere audiofilmærker</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Hvis dit sprog ikke et tilgængeligt, kan du bidrage her:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Du kan bidrage til at holde dette projekt i live ved at give en lille donation</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -221,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Ukendt kunstner</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Ukendt album</translation>
     </message>
@@ -234,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Forskellige kunstnere</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 album</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 albums</translation>
     </message>
@@ -335,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Fejl ved hentning af kunstnerinformation</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>Kunstneren kunne ikke findes</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Fejl ved hentning af albuminformation</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>Albummet kunne ikke findes</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Ingen albuminformation tilgængelig</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Fejl ved hentning af sporinformation</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>Sporet kan ikke findes</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Ingen information om spor  tilgængelig</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Henter info om kunstner</translation>
     </message>
@@ -614,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Ukendt kunstner</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Ukendt album</translation>
     </message>
@@ -674,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Forskellige kunstnere</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Ukendt album</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Ukendt kunstner</translation>
     </message>
@@ -706,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Ukendt kunstner</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Ukendt album</translation>
     </message>
@@ -844,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Vælg folder</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Ukendt kunstner</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Ukendt album</translation>
     </message>
@@ -859,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Brugerdefinerede afspilningslister</translation>
     </message>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>AboutPage</name>
     <message>
@@ -7,12 +9,12 @@
         <translation>Über</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="61"/>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
         <source>Original author:</source>
         <translation>Ursprünglicher Autor:</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="78"/>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
         <source>Contributors:</source>
         <translation>Beitragende:</translation>
     </message>
@@ -22,7 +24,7 @@
         <translation>Wenn Du eine neue Übersetzung erstellen oder eine bestehende verbessern möchtest:</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="110"/>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
         <source>You can support the original author of FlowPlayer by donating:</source>
         <translation>Du kannst den ursprünglichen Autor von FlowPlayer durch eine Spende unterstützen:</translation>
     </message>
@@ -224,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Unbekannter Künstler</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Unbekanntes Album</translation>
     </message>
@@ -237,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Diverse Künstler</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 Album</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 Alben</translation>
     </message>
@@ -338,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Fehler beim Abruf der Künstlerinformationen</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>Der Künstler konnte nicht gefunden werden</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Fehler beim Abruf der Albuminformationen</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>Das Album konnte nicht gefunden werden</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Keine Informationen zum Album verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Fehler beim Abruf der Titelinformationen</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>Der Titel konnte nicht gefunden werden</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Keine Titelinformationen verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Hole Künstlerinformationen</translation>
     </message>
@@ -617,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Unbekannter Künstler</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Unbekanntes Album</translation>
     </message>
@@ -677,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Diverse Künstler</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Unbekanntes Album</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Unbekannter Künstler</translation>
     </message>
@@ -709,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Unbekannter Künstler</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Unbekanntes Album</translation>
     </message>
@@ -847,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Ordner auswählen</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Unbekannter Künstler</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Unbekanntes Album</translation>
     </message>
@@ -862,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Eigene Playlisten</translation>
     </message>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Unbekannter Künstler</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Unbekanntes Album</translation>
     </message>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Artista desconocido</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Album desconocido</translation>
     </message>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AboutPage</name>
     <message>
@@ -7,19 +9,24 @@
         <translation>Acerca</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>La librería Taglib es usada para leer, escribir y manipular las etiquetas de los archivos de audio</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Si su idioma no se encuentra disponible puede contribuír aquí:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Usted puede contribuír a mantener este proyecto haciendo una pequeña donación</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -219,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Artista desconocido</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Album desconocido</translation>
     </message>
@@ -232,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Artistas varios</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 álbum</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 álbumes</translation>
     </message>
@@ -333,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Error al descargar información del artista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>No se encontró el artista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Error al descargar información del álbum</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>No se encontró el álbum</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>No hay información del álbum disponible</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Error al descargar información de la canción</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>No se encontró la canción</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>No hay información de la canción disponible</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Descargando información del artista</translation>
     </message>
@@ -612,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Artista desconocido</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Album desconocido</translation>
     </message>
@@ -672,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Artistas varios</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Album desconocido</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Artista desconocido</translation>
     </message>
@@ -704,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Artista desconocido</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Album desconocido</translation>
     </message>
@@ -842,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Seleccionar carpeta</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Artista desconocido</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Album desconocido</translation>
     </message>
@@ -857,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Listas personalizadas</translation>
     </message>

--- a/translations/flowplayer.ts
+++ b/translations/flowplayer.ts
@@ -19,12 +19,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="93"/>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
         <source>If you want to create a new translation or improve an extant one:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="116"/>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
         <source>You can support the original author of FlowPlayer by donating:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation type="unfinished"></translation>
     </message>
@@ -239,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation type="unfinished"></translation>
     </message>
@@ -340,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -619,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -711,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation type="unfinished"></translation>
     </message>
@@ -849,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation type="unfinished"></translation>
     </message>
@@ -864,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/flowplayer.ts
+++ b/translations/flowplayer.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Artiste inconnu</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Album inconnu</translation>
     </message>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AboutPage</name>
     <message>
@@ -7,19 +9,24 @@
         <translation>A propos</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>Taglib est utilisé pour lire, écrire et manipuler les tags de fichier audio</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Si votre langue n&apos;est pas disponible, vous pouvez contribuer ici:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Vous pouvez aider à maintenir ce projet en vie en faisant une petite donation</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -219,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Artiste inconnu</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Album inconnu</translation>
     </message>
@@ -232,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Artistes divers</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 album</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 album</translation>
     </message>
@@ -333,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Erreur lors de la recherche d&apos;informations sur l&apos;artiste</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>L&apos;artiste n&apos;a pas été trouvé</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Erreur lors de la recherche d&apos;informations sur l&apos;album</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>L&apos;album ne peut être trouvé</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Pas d&apos;information disponible sur l&apos;album</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Erreur lors de la recherche d&apos;informations sur la piste</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>La piste ne peut être trouvée</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Pas d&apos;information disponible sur la piste</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Recherche d&apos;informations sur l&apos;artiste</translation>
     </message>
@@ -612,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Artiste inconnu</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Album inconnu</translation>
     </message>
@@ -672,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Artistes divers</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Album inconnu</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Artiste inconnu</translation>
     </message>
@@ -704,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Artiste inconnu</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Album inconnu</translation>
     </message>
@@ -842,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Choisir le dossier</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Artiste inconnu</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Album inconnu</translation>
     </message>
@@ -857,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Playlists personnalisées</translation>
     </message>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Artista sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Album sconosciuto</translation>
     </message>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -9,19 +9,24 @@
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>Taglib è utilizzato per la lettura, la scrittura e la manipolazione dei tag</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Se la tua lingua non è disponibile, puoi contribuire qui:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Puoi contribuire al mantenimento di questo progetto effettuando una donazione</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -221,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Artista sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Album sconosciuto</translation>
     </message>
@@ -234,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Artisti vari</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 album</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 album</translation>
     </message>
@@ -335,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Errore nel recuperare le info sull&apos;artista</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>L&apos;artista non può essere trovato</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Errore nel recuperare le info sull&apos;album</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>L&apos;album non può essere trovato</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Nessuna info sull&apos;album disponibile</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Errore nel recuperare le info sulla traccia</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>La traccia non può essere trovata</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Nessuna info sulla traccia disponibile</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Recupero info sull&apos;artista</translation>
     </message>
@@ -614,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Artista sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Album sconosciuto</translation>
     </message>
@@ -674,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Artisti vari</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Album sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Artista sconosciuto</translation>
     </message>
@@ -706,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Artista sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Album sconosciuto</translation>
     </message>
@@ -844,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Seleziona cartella</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Artista sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Album sconosciuto</translation>
     </message>
@@ -859,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Playlist personalizzata</translation>
     </message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AboutPage</name>
     <message>
@@ -7,19 +9,24 @@
         <translation>Over</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>Taglib wordt gebruikt voor het lezen, schrijven en het manipuleren van audio file-tags</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Als uw taal niet beschikbaar is, kunt u hier uw bijdrage leveren:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Met een kleine donatie, kunt u uw bijdrage leveren en het project in leven houden.</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -219,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Onbekende artiest</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Onbekende album</translation>
     </message>
@@ -232,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Diverse artiesten</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 album</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 albums</translation>
     </message>
@@ -333,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Fout bij het ophalen van informatie over de artiest</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>Artiest kan niet worden gevonden</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Fout bij het ophalen van informatie over de album</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>Album kan niet worden gevonden</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Album informatie niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Fout bij het ophalen van informatie over de track</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>Track kan niet worden gevonden</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Track informatie niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Informatie ophalen over de artiest</translation>
     </message>
@@ -612,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Onbekende artiest</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Onbekende album</translation>
     </message>
@@ -672,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Diverse artiesten</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Onbekende album</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Onbekende artiest</translation>
     </message>
@@ -704,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Onbekende artiest</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Onbekende album</translation>
     </message>
@@ -842,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Selecteer map</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Onbekende artiest</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Onbekende album</translation>
     </message>
@@ -857,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Handmatige afspeellijsten</translation>
     </message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Onbekende artiest</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Onbekende album</translation>
     </message>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AboutPage</name>
     <message>
@@ -7,19 +9,24 @@
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="71"/>
-        <source>Taglib is used for reading, writing and manipulating audio file tags</source>
-        <translation>Taglib используется для чтения и записи тегов аудиофайлов</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
+        <source>Original author:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="81"/>
-        <source>If your language is not available you can contribute here:</source>
-        <translation>Если ваш язык недоступен, вы можете помочь в переводе здесь:</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
+        <source>Contributors:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="97"/>
-        <source>You can contribute to keep this project alive making a small donation</source>
-        <translation>Вы можете внести свой вклад в жизнь проекта, сделав небольшое пожертвование</translation>
+        <location filename="../qml/pages/AboutPage.qml" line="95"/>
+        <source>If you want to create a new translation or improve an extant one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
+        <source>You can support the original author of FlowPlayer by donating:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -219,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Неизвестный исполнитель</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Неизвестный альбом</translation>
     </message>
@@ -232,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Различные исполнители</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 альбом</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 альбомов</translation>
     </message>
@@ -333,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Ошибка при получении сведений об исполнителе</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>Исполнитель не может быть найден</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Ошибка при получении информации об альбоме</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>Альбом не найден</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Нет информации об альбоме</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Ошибка при получении информации о треке</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>Трек не найден</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Нет информации о треке</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Поиск сведений об исполнителе</translation>
     </message>
@@ -612,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Неизвестный исполнитель</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Неизвестный альбом</translation>
     </message>
@@ -672,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Различные исполнители</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Неизвестный альбом</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Неизвестный исполнитель</translation>
     </message>
@@ -704,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Неизвестный исполнитель</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Неизвестный альбом</translation>
     </message>
@@ -842,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Выбрать папку</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Неизвестный исполнитель</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Неизвестный альбом</translation>
     </message>
@@ -857,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Собственные плейлисты</translation>
     </message>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Неизвестный исполнитель</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Неизвестный альбом</translation>
     </message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -226,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="230"/>
+        <location filename="../src/datareader.cpp" line="236"/>
         <source>Unknown artist</source>
         <translation>Okänd artist</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="231"/>
+        <location filename="../src/datareader.cpp" line="237"/>
         <source>Unknown album</source>
         <translation>Okänt album</translation>
     </message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sv">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
 <context>
     <name>AboutPage</name>
     <message>
@@ -7,12 +9,12 @@
         <translation>Om</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="61"/>
+        <location filename="../qml/pages/AboutPage.qml" line="63"/>
         <source>Original author:</source>
         <translation>Ursprunglig utvecklare:</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="78"/>
+        <location filename="../qml/pages/AboutPage.qml" line="75"/>
         <source>Contributors:</source>
         <translation>Bidragande parter:</translation>
     </message>
@@ -22,7 +24,7 @@
         <translation>Om du vill skapa en ny översättning eller förbättra en befintlig:</translation>
     </message>
     <message>
-        <location filename="../qml/pages/AboutPage.qml" line="110"/>
+        <location filename="../qml/pages/AboutPage.qml" line="118"/>
         <source>You can support the original author of FlowPlayer by donating:</source>
         <translation>Du kan stödja den ursprungliga utvecklaren av FlowPlayer genom att donera:</translation>
     </message>
@@ -224,12 +226,12 @@
 <context>
     <name>DataReader</name>
     <message>
-        <location filename="../src/datareader.cpp" line="202"/>
+        <location filename="../src/datareader.cpp" line="230"/>
         <source>Unknown artist</source>
         <translation>Okänd artist</translation>
     </message>
     <message>
-        <location filename="../src/datareader.cpp" line="203"/>
+        <location filename="../src/datareader.cpp" line="231"/>
         <source>Unknown album</source>
         <translation>Okänt album</translation>
     </message>
@@ -237,17 +239,17 @@
 <context>
     <name>Datos</name>
     <message>
-        <location filename="../src/datos.cpp" line="145"/>
+        <location filename="../src/datos.cpp" line="146"/>
         <source>Various artists</source>
         <translation>Diverse artister</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>1 album</source>
         <translation>1 album</translation>
     </message>
     <message>
-        <location filename="../src/datos.cpp" line="325"/>
+        <location filename="../src/datos.cpp" line="326"/>
         <source>%1 albums</source>
         <translation>%1 album</translation>
     </message>
@@ -338,48 +340,48 @@
 <context>
     <name>LFM</name>
     <message>
-        <location filename="../src/lfm.cpp" line="46"/>
-        <location filename="../src/lfm.cpp" line="106"/>
+        <location filename="../src/lfm.cpp" line="48"/>
+        <location filename="../src/lfm.cpp" line="108"/>
         <source>Error fetching artist information</source>
         <translation>Fel vid hämtning av artistinformation</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="58"/>
+        <location filename="../src/lfm.cpp" line="60"/>
         <source>The artist could not be found</source>
         <translation>Artisten kunde inte hittas</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="123"/>
+        <location filename="../src/lfm.cpp" line="125"/>
         <source>Error fetching album information</source>
         <translation>Fel vid hämtning av albuminformation</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="135"/>
+        <location filename="../src/lfm.cpp" line="137"/>
         <source>The album could not be found</source>
         <translation>Albumet kunde inte hittas</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="162"/>
+        <location filename="../src/lfm.cpp" line="164"/>
         <source>No album information available</source>
         <translation>Ingen albuminformation tillgänglig</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="198"/>
+        <location filename="../src/lfm.cpp" line="200"/>
         <source>Error fetching track information</source>
         <translation>Fel vid hämtning av spårinformation</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="212"/>
+        <location filename="../src/lfm.cpp" line="214"/>
         <source>The track could not be found</source>
         <translation>Spåret kunde inte hittas</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="237"/>
+        <location filename="../src/lfm.cpp" line="239"/>
         <source>No track information available</source>
         <translation>Ingen spårinformation tillgänglig</translation>
     </message>
     <message>
-        <location filename="../src/lfm.cpp" line="280"/>
+        <location filename="../src/lfm.cpp" line="282"/>
         <source>Fetching artist information</source>
         <translation>Hämtar artistinformation</translation>
     </message>
@@ -617,12 +619,12 @@
 <context>
     <name>Meta</name>
     <message>
-        <location filename="../src/meta.cpp" line="60"/>
+        <location filename="../src/meta.cpp" line="63"/>
         <source>Unknown artist</source>
         <translation>Okänd artist</translation>
     </message>
     <message>
-        <location filename="../src/meta.cpp" line="61"/>
+        <location filename="../src/meta.cpp" line="64"/>
         <source>Unknown album</source>
         <translation>Okänt album</translation>
     </message>
@@ -677,17 +679,17 @@
 <context>
     <name>Missing</name>
     <message>
-        <location filename="../src/missing.cpp" line="74"/>
+        <location filename="../src/missing.cpp" line="75"/>
         <source>Various artists</source>
         <translation>Diverse artister</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown album</source>
         <translation>Okänt album</translation>
     </message>
     <message>
-        <location filename="../src/missing.cpp" line="78"/>
+        <location filename="../src/missing.cpp" line="79"/>
         <source>Unknown artist</source>
         <translation>Okänd artist</translation>
     </message>
@@ -709,12 +711,12 @@
 <context>
     <name>MyPlaylist</name>
     <message>
-        <location filename="../src/myplaylist.cpp" line="70"/>
+        <location filename="../src/myplaylist.cpp" line="71"/>
         <source>Unknown artist</source>
         <translation>Okänd artist</translation>
     </message>
     <message>
-        <location filename="../src/myplaylist.cpp" line="72"/>
+        <location filename="../src/myplaylist.cpp" line="73"/>
         <source>Unknown album</source>
         <translation>Okänt album</translation>
     </message>
@@ -847,14 +849,22 @@
     </message>
 </context>
 <context>
+    <name>PickFolder</name>
+    <message>
+        <location filename="../qml/pages/PickFolder.qml" line="7"/>
+        <source>Select folder</source>
+        <translation type="unfinished">Välj mapp</translation>
+    </message>
+</context>
+<context>
     <name>Playlist</name>
     <message>
-        <location filename="../src/playlist.cpp" line="158"/>
+        <location filename="../src/playlist.cpp" line="159"/>
         <source>Unknown artist</source>
         <translation>Okänd artist</translation>
     </message>
     <message>
-        <location filename="../src/playlist.cpp" line="160"/>
+        <location filename="../src/playlist.cpp" line="161"/>
         <source>Unknown album</source>
         <translation>Okänt album</translation>
     </message>
@@ -862,7 +872,7 @@
 <context>
     <name>PlaylistManager</name>
     <message>
-        <location filename="../src/playlistmanager.cpp" line="347"/>
+        <location filename="../src/playlistmanager.cpp" line="345"/>
         <source>Custom playlists</source>
         <translation>Anpassade spelningslistor</translation>
     </message>


### PR DESCRIPTION
This PR contains 3 primary changes all related to obtaining local cover art, especially when cover art cannot be otherwise found.
1. Cleans up the `GenericCacheLocation` use in favour of the application specific `CacheLocation`.
2.  Ensures the location exists (to be exact, that the sub-directory `media-art` exists) and enforces its use with Sailjail.
3. Adds a method to `datareader.cpp` to check, if album and artist are known, if a file's containing directory contains a jpg/jpeg and if so, copy it to the album art cache.