### PR TITLE
Use the app config dir to save the QSettings file.

### DIFF
--- a/src/FlowPlayer.cpp
+++ b/src/FlowPlayer.cpp
@@ -7,6 +7,8 @@
 #include <sailfishapp.h>
 #include <QObject>
 #include <QTextCodec>
+#include <QSettings>
+#include <QStandardPaths>
 
 #include "playlistmanager.h"
 #include "utils.h"
@@ -34,7 +36,7 @@ int main(int argc, char *argv[])
     QString lang;
     QTranslator translator;
 
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     lang = settings.value("Language", "undefined").toString();
 
     if (lang=="undefined")

--- a/src/coversearch.cpp
+++ b/src/coversearch.cpp
@@ -7,6 +7,7 @@
 #include <QStringList>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSettings>
 #include <QStandardPaths>
 
 #define BING_ID "A16EECFD14108C2794E4BC29D4DE59C308685B4A"
@@ -165,7 +166,7 @@ void CoverSearch::remove(const QString &file)
     QString nf = file;
     if ( nf.startsWith("//") )
         nf.remove(0, 1);
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QStringList entries = settings.value("CoverSearch","").toStringList();
     QStringList newfiles;
     for (int i=0; i< entries.count(); ++i)

--- a/src/datareader.cpp
+++ b/src/datareader.cpp
@@ -271,7 +271,7 @@ void DataReader::run()
     favFiles.clear();
     map.clear();
 
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QStringList folders = settings.value("Folders","").toString().split("<separator>");
     folders.removeAll("");
 

--- a/src/datos.cpp
+++ b/src/datos.cpp
@@ -233,7 +233,7 @@ void Datos::addFilterToQueue()
     }*/
 
     QString norder;
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QString order = settings.value("TrackOrder", "title").toString();
 
     if (order=="title") norder="title";
@@ -429,7 +429,7 @@ QString Datos::getArtistsCovers()
             dato1.append(coverart);
     }
 
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     int first = settings.value("LastArtistItem", 0).toInt();
 
     if (first >= dato1.count()) {
@@ -463,7 +463,7 @@ QString Datos::getAlbumsCovers()
             dato1.append(coverart);
     }
 
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     int first = settings.value("LastAlbumItem", 0).toInt();
 
     if (first >= dato1.count()) {

--- a/src/lfm.cpp
+++ b/src/lfm.cpp
@@ -31,7 +31,7 @@ LFM::LFM(QQuickItem *parent)
     //connect(datos5, SIGNAL(finished(QNetworkReply*)), this, SLOT(downloaded5(QNetworkReply*)));
     //connect(datos6, SIGNAL(finished(QNetworkReply*)), this, SLOT(downloaded6(QNetworkReply*)));
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     lang = sets.value("LastFMlang", "en").toString();
 }
 
@@ -277,7 +277,7 @@ void LFM::getBio(QString artist)
 
     //if ( reply1 && reply1->isRunning() )
     //    reply1->abort();
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     lang = sets.value("Language", "en").toString();
     artistInfo = tr("Fetching artist information");
     artistInfoLarge = "";
@@ -301,7 +301,7 @@ void LFM::getAlbumBio(QString artist, QString album)
 {
     /*if ( reply2 && reply2->isRunning() )
         reply2->abort();
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     lang = sets.value("LastFMlang", "en").toString();
     albumInfo = tr("Fetching album information");
     albumInfoLarge = "";
@@ -316,7 +316,7 @@ void LFM::getSongBio(QString artist, QString song)
 {
     /*if ( reply3 && reply3->isRunning() )
         reply3->abort();
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     lang = sets.value("LastFMlang", "en").toString();
     songInfo = tr("Fetching track information");
     songInfoLarge = "";

--- a/src/loadimage.cpp
+++ b/src/loadimage.cpp
@@ -6,7 +6,6 @@
 #include <qfileinfo.h>
 #include <qdir.h>
 #include <QImage>
-#include <QSettings>
 #include <QDebug>
 #include <QStandardPaths>
 

--- a/src/loadwebimage.cpp
+++ b/src/loadwebimage.cpp
@@ -7,7 +7,6 @@
 #include <qfileinfo.h>
 #include <qdir.h>
 #include <QImage>
-#include <QSettings>
 #include <QDebug>
 #include <QDateTime>
 #include <QStandardPaths>

--- a/src/missing.cpp
+++ b/src/missing.cpp
@@ -8,7 +8,6 @@
 #include <QImage>
 #include <QStringList>
 #include <QXmlStreamReader>
-#include <QSettings>
 #include <QStandardPaths>
 
 bool namefileLess(const QStringList &d1, const QStringList &d2)

--- a/src/musicmodel.cpp
+++ b/src/musicmodel.cpp
@@ -57,7 +57,7 @@ void MusicModel::loadData(QString artist, QString album, QString various)
 
     if (!isDBOpened) openDatabase();
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QString torder = sets.value("TrackOrder", "title").toString();
     QString order;
     if (torder=="title") order="title";

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3,6 +3,7 @@
 
 #include <QTimer>
 #include <QSettings>
+#include <QStandardPaths>
 #include "QVariantMap"
 
 extern bool databaseWorking;
@@ -20,7 +21,7 @@ static gboolean bus_cb (GstBus *bus, GstMessage *msg, gpointer data)
 static void prepare_next_stream(GstElement *obj, gpointer data) {
     qDebug() << "ABOUT TO FINISH";
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     if (sets.value("GaplessPlayback", "no").toString()=="no")
         return;
 
@@ -421,7 +422,7 @@ void Player::backend_deinit()
 void Player::setEq(bool enabled)
 {
     qDebug() << "Setting eq: " << enabled;
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     sets.setValue("Equalizer", enabled? "Yes" : "No");
     sets.sync();
 
@@ -472,7 +473,7 @@ void Player::setEqualizerReal(int band, int value)
 
 void Player::loadEqualizer()
 {
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     m_eqenabled = sets.value("Equalizer", "No").toString()=="Yes";
     emit eqEnabledChanged();
 

--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -24,14 +24,14 @@ int Playlist::current()
 
 QString Playlist::active() const
 {
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QString t = sets.value("Active", "false").toString();
     return t;
 }
 
 QString Playlist::unknown() const
 {
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QString t = sets.value("Unknown", "false").toString();
     return t;
 }
@@ -416,7 +416,7 @@ void Playlist::changeUnknown(bool active)
 {
     //qDebug() << "CHANGING UKNOWN: " << active;
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     sets.setValue("Unknown", active);
     sets.sync();
 }
@@ -425,7 +425,7 @@ void Playlist::changeMode(QString mode)
 {
     //qDebug() << "CHANGING MODE: " << mode;
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     sets.setValue("Mode", mode);
     sets.sync();
 }

--- a/src/playlistmanager.cpp
+++ b/src/playlistmanager.cpp
@@ -1,6 +1,7 @@
 #include "playlistmanager.h"
 
 #include <QSettings>
+#include <QStandardPaths>
 #include <QFileInfo>
 #include <QXmlStreamReader>
 #include <QDir>
@@ -89,7 +90,7 @@ void PlaylistManager::addAlbumToList(QString list, QString artist, QString album
 
     if (!isDBOpened) openDatabase();
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QString torder = sets.value("TrackOrder", "title").toString();
     QString order;
     if (torder=="title") order="title";
@@ -431,7 +432,7 @@ void PlaylistManager::loadAlbum(QString artist, QString album, QString various)
 
     if (!isDBOpened) openDatabase();
 
-    QSettings sets;
+    QSettings sets(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QString torder = sets.value("TrackOrder", "title").toString();
     QString order;
     if (torder=="title") order="title";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -440,81 +440,81 @@ void Utils::removePreview()
 
 void Utils::setSettings(QString set, QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue(set, val);
     settings.sync();
 }
 
 QString Utils::readSettings(QString set, QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value(set, val).toString();
 }
 
 QString Utils::showReflection()
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("ShowReflection", "true").toString();
 }
 
 QString Utils::viewmode() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("ViewMode", "grid").toString();
 }
 
 QString Utils::paging() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("Paging", "multiple").toString();
 }
 
 QString Utils::scrobble() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("Scrobble", "false").toString();
 }
 
 QString Utils::order() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("SortOrder", "album").toString();
 }
 
 QString Utils::lang() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("LastFMlang", "en").toString();
 }
 
 QString Utils::updatestart() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("UpdateOnStartup", "no").toString();
 }
 
 QString Utils::autosearch() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("AutoSearchLyrics", "yes").toString();
 }
 
 QString Utils::cleanqueue() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("CleanQueue", "yes").toString();
 }
 
 QString Utils::workoffline() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("WorkOffline", "no").toString();
 }
 
 
 void Utils::setViewMode(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("ViewMode", val);
     settings.sync();
     emit viewmodeChanged();
@@ -522,7 +522,7 @@ void Utils::setViewMode(QString val)
 
 void Utils::setPaging(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("Paging", val);
     settings.sync();
     emit pagingChanged();
@@ -530,7 +530,7 @@ void Utils::setPaging(QString val)
 
 void Utils::setScrobble(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("Scrobble", val);
     settings.sync();
     emit scrobbleChanged();
@@ -538,7 +538,7 @@ void Utils::setScrobble(QString val)
 
 void Utils::setOrder(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("SortOrder", val);
     settings.sync();
     emit orderChanged();
@@ -546,7 +546,7 @@ void Utils::setOrder(QString val)
 
 void Utils::setLang(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("LastFMlang", val);
     settings.sync();
     emit langChanged();
@@ -554,7 +554,7 @@ void Utils::setLang(QString val)
 
 void Utils::setUpdateStart(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("UpdateOnStartup", val);
     settings.sync();
     emit updateChanged();
@@ -562,7 +562,7 @@ void Utils::setUpdateStart(QString val)
 
 void Utils::setAutoSearch(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("AutoSearchLyrics", val);
     settings.sync();
     emit autosearchChanged();
@@ -570,7 +570,7 @@ void Utils::setAutoSearch(QString val)
 
 void Utils::setCleanQueue(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("CleanQueue", val);
     settings.sync();
     emit queueChanged();
@@ -578,7 +578,7 @@ void Utils::setCleanQueue(QString val)
 
 void Utils::setWorkOffline(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("WorkOffline", val);
     settings.sync();
     emit workofflineChanged();
@@ -586,13 +586,13 @@ void Utils::setWorkOffline(QString val)
 
 QString Utils::orientation() const
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("Orientation", "auto").toString();
 }
 
 void Utils::setOrientation(QString val)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     settings.setValue("Orientation", val);
     settings.sync();
     emit orientationChanged();
@@ -607,7 +607,7 @@ QString Utils::plainLyrics(QString text)
 
 QString Utils::version()
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     return settings.value("Firmware", "PR10").toString();
 }
 
@@ -644,7 +644,7 @@ void Utils::removeAlbumArt()
 
 void Utils::getFolders()
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QStringList folders = settings.value("Folders","").toString().split("<separator>");
     folders.removeAll("");
 
@@ -708,7 +708,7 @@ void Utils::getFolderItems(QString path)
 
 void Utils::addFolderToList(QString path)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QStringList folders = settings.value("Folders","").toString().split("<separator>");
     folders.removeAll("");
     folders.append(path);
@@ -720,7 +720,7 @@ void Utils::addFolderToList(QString path)
 
 void Utils::removeFolder(QString path)
 {
-    QSettings settings;
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/flowplayer.conf", QSettings::NativeFormat);
     QStringList folders = settings.value("Folders","").toString().split("<separator>");
     folders.removeAll("");
     folders.removeAll(path);


### PR DESCRIPTION
Close #99.

Sailjail is not mounting the generic config dir, so the QSettings file should be under org/app/ dir and not under the org/ dir. See https://forum.sailfishos.org/t/application-data-dir-sailjail-and-organizationname/6471/14 for more details.

This is a conflict between the fact that QSettings stores its file in a shared directory by default and that isolation impose to hide shared directories and use only private directories.

It's also a bit of an issue because the old conf file is not visible from inside the jail and thus running flowplayer inside the jail cannot migrate the user conf file to its new proper location. Jolla thought about this, but it's only working for harbour compliant applications (which was not the case of flowplayer) where the directory naming convention is using the harbour- prefix. So accepting this PR will result in the QSettings file being recreated and the user starting with a "new" flowplayer. The directories to parse for music will be lost for instance and will have to be reset. There is a possibility to migrate the file manually as a `postinst` rule in the RPM, dealing with the primary user, but that's error prone and ugly (the packkaging system is not the place to do this).